### PR TITLE
Listing availability entries by owner account id

### DIFF
--- a/src/main/java/science/icebreaker/device_availability/ControllerValidators/HasFiltersConstraint.java
+++ b/src/main/java/science/icebreaker/device_availability/ControllerValidators/HasFiltersConstraint.java
@@ -1,0 +1,24 @@
+package science.icebreaker.device_availability.ControllerValidators;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * Defines a constraint for checking if at least one of a method
+ * params is not null.
+ */
+@Target({ ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = HasFiltersValidator.class)
+@Documented
+public @interface HasFiltersConstraint {
+    String message() default "Must provide at least one filter";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/science/icebreaker/device_availability/ControllerValidators/HasFiltersValidator.java
+++ b/src/main/java/science/icebreaker/device_availability/ControllerValidators/HasFiltersValidator.java
@@ -1,0 +1,32 @@
+package science.icebreaker.device_availability.ControllerValidators;
+
+import java.util.Arrays;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.constraintvalidation.SupportedValidationTarget;
+import javax.validation.constraintvalidation.ValidationTarget;
+
+import science.icebreaker.device_availability.Exceptions.InvalidFiltersException;
+
+@SupportedValidationTarget(ValidationTarget.PARAMETERS)
+public class HasFiltersValidator implements ConstraintValidator<HasFiltersConstraint, Object[]> {
+
+    /**
+     * Given a list of params passed to a controller, checks if 
+     * at least one is not null
+     * 
+     * @param values The params passed
+     * @param conext
+     * @return true if the params satisfy the validation condition.
+     * @throws InvalidFiltersException if all params are null.
+     */
+    @Override
+    public boolean isValid(Object[] values, ConstraintValidatorContext context) {
+
+        Boolean hasFilters = Arrays.asList(values).stream().anyMatch((obj) -> obj != null);
+
+        if(hasFilters) return true;
+        else throw new InvalidFiltersException("Must provide at least one filter param");
+    }
+}

--- a/src/main/java/science/icebreaker/device_availability/DeviceAvailabilityController.java
+++ b/src/main/java/science/icebreaker/device_availability/DeviceAvailabilityController.java
@@ -1,5 +1,6 @@
 package science.icebreaker.device_availability;
 
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 
 import java.util.List;
@@ -7,7 +8,10 @@ import java.util.stream.Collectors;
 
 import javax.validation.Valid;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,9 +22,12 @@ import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import science.icebreaker.account.Account;
+import science.icebreaker.device_availability.ControllerValidators.HasFiltersConstraint;
 import science.icebreaker.device_availability.Exceptions.DeviceAvailabilityCreationException;
+import science.icebreaker.device_availability.Exceptions.InvalidFiltersException;
 import springfox.documentation.annotations.ApiIgnore;
 
+@Validated
 @RestController
 @RequestMapping("/device-availability")
 public class DeviceAvailabilityController {
@@ -52,10 +59,31 @@ public class DeviceAvailabilityController {
 
     @GetMapping("/")
     @ApiParam(name="device")
-    public List<GetDeviceAvailabilityResponse> getDeviceAvailability(@RequestParam(name="device") Integer deviceId) {
-        return service.getDeviceAvailability(deviceId)
+    @HasFiltersConstraint
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "List of availability entries"),
+        @ApiResponse(code = 400, message = "Filter params provided not valid")
+    })
+    public List<GetDeviceAvailabilityResponse> getDeviceAvailability(
+        @RequestParam(name="device", required=false) Integer deviceId,
+        @RequestParam(required=false) Integer ownerId
+        ) {
+            return service.getDeviceAvailability(
+                    deviceId,
+                    ownerId
+                )
                 .stream()
                 .map(GetDeviceAvailabilityResponse::fromEntity)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Handles the custom validation error {@link InvalidFiltersException}
+     * @param ex
+     * @return The response object
+     */
+    @ExceptionHandler
+    public ResponseEntity<String> handleException(InvalidFiltersException ex) {
+        return new ResponseEntity<String>(ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/science/icebreaker/device_availability/DeviceAvailabilityService.java
+++ b/src/main/java/science/icebreaker/device_availability/DeviceAvailabilityService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Example;
 import org.springframework.stereotype.Service;
 
 import science.icebreaker.account.Account;
@@ -74,12 +75,26 @@ public class DeviceAvailabilityService {
     }
 
     /**
-     * Gets all availability records related to a specific device
+     * Gets all availability records based on some criteria
      * 
      * @param deviceId The device id to search availabilities for
+     * @param ownerId The id of the owner of the device entry
      * @return A list of the device availabilities
      */
-    public List<DeviceAvailability> getDeviceAvailability(Integer deviceId) {
-        return this.deviceAvailabilityRepository.findByDeviceId(deviceId);
+    public List<DeviceAvailability> getDeviceAvailability(Integer deviceId, Integer ownerId) {
+        WikiPage device = null;
+        if(deviceId != null) {
+            device = new WikiPage();
+            device.setId(deviceId);
+        }
+        Account account = null;
+        if(ownerId != null) {
+            account = new Account();
+            account.setId(ownerId);
+        }
+        DeviceAvailability availabilityEntry = new DeviceAvailability();
+        availabilityEntry.setAccount(account);
+        availabilityEntry.setDevice(device);
+        return this.deviceAvailabilityRepository.findAll(Example.of(availabilityEntry));
     }
 }

--- a/src/main/java/science/icebreaker/device_availability/Exceptions/InvalidFiltersException.java
+++ b/src/main/java/science/icebreaker/device_availability/Exceptions/InvalidFiltersException.java
@@ -1,0 +1,11 @@
+package science.icebreaker.device_availability.Exceptions;
+
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.http.HttpStatus;
+
+@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+public class InvalidFiltersException extends RuntimeException {
+	public InvalidFiltersException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/science/icebreaker/device_availability/GetDeviceAvailabilityResponse.java
+++ b/src/main/java/science/icebreaker/device_availability/GetDeviceAvailabilityResponse.java
@@ -1,19 +1,29 @@
 package science.icebreaker.device_availability;
 
 public class GetDeviceAvailabilityResponse {
+    private Integer deviceId;
     private Integer accountId;
     private String comment;
     private String germanPostalCode;
     private String institution;
     private String researchGroup;
 
-    public GetDeviceAvailabilityResponse(Integer accountId, String comment, String germanPostalCode, String institution,
+    public GetDeviceAvailabilityResponse(Integer deviceId, Integer accountId, String comment, String germanPostalCode, String institution,
         String researchGroup) {
+        this.deviceId = deviceId;
         this.accountId = accountId;
         this.comment = comment;
         this.germanPostalCode = germanPostalCode;
         this.institution = institution;
         this.researchGroup = researchGroup;
+    }
+
+    public Integer getDeviceId() {
+        return deviceId;
+    }
+
+    public void setDeviceId(Integer deviceId) {
+        this.deviceId = deviceId;
     }
 
     public Integer getAccountId() {
@@ -58,6 +68,7 @@ public class GetDeviceAvailabilityResponse {
 
     public static GetDeviceAvailabilityResponse fromEntity(DeviceAvailability deviceAvailability) {
         return new GetDeviceAvailabilityResponse(
+            deviceAvailability.getDevice().getId(),
             deviceAvailability.getAccount().getId(), 
             deviceAvailability.getComment(),
             deviceAvailability.getGermanPostalCode(),

--- a/src/test/java/science/icebreaker/device_availability/DeviceAvailabilityServiceTest.java
+++ b/src/test/java/science/icebreaker/device_availability/DeviceAvailabilityServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.test.context.ActiveProfiles;
 import science.icebreaker.account.Account;
 import science.icebreaker.account.AccountCreationException;
+import science.icebreaker.account.AccountProfile;
 import science.icebreaker.account.AccountRepository;
 import science.icebreaker.account.AccountService;
 import science.icebreaker.account.RegistrationRequest;
@@ -118,7 +119,7 @@ public class DeviceAvailabilityServiceTest {
             new DeviceAvailability(2, device, "comment", "67660", "TUM", "Informatik People", this.account));
 
         List<DeviceAvailability> deviceAvailabilityList = 
-            this.deviceAvailabilityService.getDeviceAvailability(device.getId());
+            this.deviceAvailabilityService.getDeviceAvailability(device.getId(), null);
             
         assertThat(deviceAvailabilityList.size()).isEqualTo(2);
     }
@@ -128,8 +129,57 @@ public class DeviceAvailabilityServiceTest {
         Integer deviceId = 1;
 
         List<DeviceAvailability> deviceAvailabilityList = 
-            this.deviceAvailabilityService.getDeviceAvailability(deviceId);
+            this.deviceAvailabilityService.getDeviceAvailability(deviceId, null);
 
         assertThat(deviceAvailabilityList.size()).isEqualTo(0);
     }
+
+    @Test
+    public void getDeviceAvailabilityOfUser_empty_success() {
+        List<DeviceAvailability> deviceAvailabilityList = 
+            this.deviceAvailabilityService.getDeviceAvailability(null, this.account.getId());
+
+        assertThat(deviceAvailabilityList.size()).isEqualTo(0);
+    }
+
+    /**
+     * Creates two accounts and associates 2 devices with each, then checks the
+     * method response when fetching device for one user
+     * @throws AccountCreationException
+     */
+    @Test 
+    public void getDeviceAvailabilityOfUser_exists_success() throws AccountCreationException {
+        RegistrationRequest request = new RegistrationRequest();
+        Account account = new Account(null, "test2@test.com", "secure");
+        AccountProfile accountProfile = new AccountProfile();
+        accountProfile.setForename("F");
+        accountProfile.setSurname("S");
+        accountProfile.setInstitution("TU KL");
+        accountProfile.setCity("KL");
+        accountProfile.setResearchArea("Chemistry Stuff");
+        request.setAccount(account);
+        request.setProfile(accountProfile);
+
+        Integer id = this.accountService.createAccount(request);
+        Account otherAccount = new Account();
+        otherAccount.setId(id);
+
+        WikiPage device = new WikiPage(WikiPage.PageType.DEVICE, "device title", "device description", "device references");
+        device = this.wikiPageRepository.save(device);
+
+        this.deviceAvailabilityRepository.save(
+            new DeviceAvailability(1, device, "comment", "67660", "TU KL", "Informatik People", this.account));
+        this.deviceAvailabilityRepository.save(
+            new DeviceAvailability(2, device, "comment", "67660", "TUM", "Informatik People", this.account));
+
+        this.deviceAvailabilityRepository.save(
+            new DeviceAvailability(1, device, "comment", "67660", "TU KL", "Informatik People", otherAccount));
+        this.deviceAvailabilityRepository.save(
+            new DeviceAvailability(2, device, "comment", "67660", "TUM", "Informatik People", otherAccount));
+
+        List<DeviceAvailability> deviceAvailabilityList =
+            this.deviceAvailabilityService.getDeviceAvailability(null, this.account.getId());
+
+        assertThat(deviceAvailabilityList.size()).isEqualTo(2);
+    } 
 }


### PR DESCRIPTION
Closes #18 
I went with the suggestion of querying the device availability endpoint directly. Since we already have one for fetching by device id, I used the same endpoint and implemented it in such a way that we can query availability entries by specifying criteria.