### PR TITLE
Improve response if validation fails

### DIFF
--- a/src/main/java/science/icebreaker/validation/GlobalValidationExceptionHandler.java
+++ b/src/main/java/science/icebreaker/validation/GlobalValidationExceptionHandler.java
@@ -1,0 +1,70 @@
+package science.icebreaker.validation;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import science.icebreaker.validation.exception.IllegalRequestParameterException;
+
+import java.util.*;
+
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.*;
+
+/*
+ * This class reformats the api response for invalid input annotated with @Valid
+ * */
+@ControllerAdvice
+public class GlobalValidationExceptionHandler extends ResponseEntityExceptionHandler {
+
+    // error handle for @Valid
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+                                                                  HttpHeaders headers, HttpStatus status,
+                                                                  WebRequest request) {
+
+        Map<String, List<FieldError>> errorsByField = ex.getBindingResult().getFieldErrors().stream()
+                .collect(groupingBy(FieldError::getField, toList()));
+
+        Map<String, List<String>> errors = errorsByField.entrySet().stream().collect(toMap(
+                Map.Entry::getKey,
+                entry -> {
+                    List<String> errorMessages = new ArrayList<>();
+                    for (FieldError fieldError : entry.getValue()) {
+                        // return only NotNull error if field contains NotNull error
+                        if (Objects.equals(fieldError.getCode(), "NotNull")) {
+                            return singletonList(fieldError.getDefaultMessage());
+                        } else {
+                            errorMessages.add(fieldError.getDefaultMessage());
+                        }
+                    }
+                    return errorMessages;
+                }
+        ));
+
+        return formatErrorResponse(headers, status, errors);
+    }
+
+    // error handle for IllegalRequestParameterException
+    @ExceptionHandler({IllegalRequestParameterException.class})
+    public Object handleConstraintViolation(IllegalRequestParameterException ex) {
+        return formatErrorResponse(new HttpHeaders(), HttpStatus.BAD_REQUEST,
+                singletonMap(ex.getField(), singletonList(ex.getMessage())));
+    }
+
+    private ResponseEntity<Object> formatErrorResponse(HttpHeaders headers, HttpStatus status,
+                                                       Map<String, List<String>> errors) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", new Date());
+        body.put("status", status.value());
+        body.put("error", status.getReasonPhrase());
+        body.put("errors", errors);
+        return new ResponseEntity<>(body, headers, status);
+    }
+}

--- a/src/main/java/science/icebreaker/validation/exception/IllegalRequestParameterException.java
+++ b/src/main/java/science/icebreaker/validation/exception/IllegalRequestParameterException.java
@@ -1,4 +1,4 @@
-package science.icebreaker.utils;
+package science.icebreaker.validation.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -6,7 +6,14 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @ResponseStatus(HttpStatus.BAD_REQUEST)
 public class IllegalRequestParameterException extends RuntimeException {
 
-    public IllegalRequestParameterException(String message) {
+    private final String field;
+
+    public IllegalRequestParameterException(String field, String message) {
         super(message);
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
     }
 }

--- a/src/main/java/science/icebreaker/wiki/WikiController.java
+++ b/src/main/java/science/icebreaker/wiki/WikiController.java
@@ -4,7 +4,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.springframework.web.bind.annotation.*;
-import science.icebreaker.utils.IllegalRequestParameterException;
+import science.icebreaker.validation.exception.IllegalRequestParameterException;
 
 import javax.validation.Valid;
 import java.util.List;
@@ -26,7 +26,7 @@ public class WikiController {
     public int addWikiPage(@RequestBody @Valid WikiPage wikiPage) throws IllegalRequestParameterException {
         // prevent modification of existing wiki pages
         if (wikiPage.getId() != 0) {
-            throw new IllegalRequestParameterException("ID must not been set.");
+            throw new IllegalRequestParameterException("id", "ID must not been set.");
         }
         WikiPage res = wikiPageRepository.save(wikiPage);
         return res.getId();

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -1,0 +1,3 @@
+javax.validation.constraints.Email.message=Email must be a valid address.
+javax.validation.constraints.NotNull.message=Field is required.
+javax.validation.constraints.NotBlank.message=Field can not be blank.

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -1,3 +1,3 @@
 javax.validation.constraints.Email.message=Email must be a valid address.
 javax.validation.constraints.NotNull.message=Field is required.
-javax.validation.constraints.NotBlank.message=Field may not be blank.
+javax.validation.constraints.NotBlank.message=Field must not be blank.

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -1,3 +1,3 @@
 javax.validation.constraints.Email.message=Email must be a valid address.
 javax.validation.constraints.NotNull.message=Field is required.
-javax.validation.constraints.NotBlank.message=Field can not be blank.
+javax.validation.constraints.NotBlank.message=Field may not be blank.


### PR DESCRIPTION
Send more detailed response of validation fails.
Can be used to give feedback in the frontend.

Example response:
```
{
  "timestamp": "2020-09-07T18:00:00.000+00:00",
  "status": 400,
  "error": "Bad Request",
  "errors": {
    "name": [
      "Field is required."
    ],
    "email": [
      "Email must be a valid address."
    ]
  }
}
```