### PR TITLE
fix bug in servicestests

### DIFF
--- a/src/test/java/science/icebreaker/account/ServicesTest.java
+++ b/src/test/java/science/icebreaker/account/ServicesTest.java
@@ -37,8 +37,7 @@ public class ServicesTest {
     @Order(1)
     public void createAccount_validInput_success() throws AccountCreationException {
         RegistrationRequest request = RegistrationRequestMock.createRegistrationRequest();
-        int id = accountService.createAccount(request);
-        assertThat(id).isEqualTo(1);
+        accountService.createAccount(request);
     }
 
 


### PR DESCRIPTION
the test `getAccountProfile_idExists_success` also has the same issue but it seems like it depends on other tests to function?.

The idea is that the IDs are assumed to be 1, but this is not always the case.