### PR TITLE
Reject disabled account login and allow creation of accounts regardless of mail server status

### DIFF
--- a/src/main/java/science/icebreaker/account/AccountService.java
+++ b/src/main/java/science/icebreaker/account/AccountService.java
@@ -131,14 +131,14 @@ public class AccountService {
         // TODO Save the data in a single transaction
         try {
             Account savedAccount = accountRepository.save(account);
+            int accountId = account.getId();
+            accountRoleRepository.save(new AccountRole(account.getEmail(), "USER"));
+            profile.setAccountId(accountId);
+            accountProfileRepository.save(profile);
             saveAccountConfirmationTokenAndSendEmail(savedAccount);
         } catch (DataIntegrityViolationException e) {
             throw new AccountCreationException().withErrorCode(ErrorCodeEnum.ERR_ACC_001);
         }
-        int accountId = account.getId();
-        accountRoleRepository.save(new AccountRole(account.getEmail(), "USER"));
-        profile.setAccountId(accountId);
-        accountProfileRepository.save(profile);
 
         return account.getId();
     }
@@ -227,5 +227,19 @@ public class AccountService {
         String subject = "Complete Registration!";
 
         mailService.sendMail(email, message, subject);
+    }
+
+    /**
+     * Forcefully sets a disabled account to enabled
+     * CAUTION: used only for internal purposes
+     * @param email
+     */
+    public void enableAccount(String email) {
+        Account account = accountRepository.findAccountByEmail(email);
+        if (account == null) {
+            throw new AccountNotFoundException();
+        }
+        account.setEnabled(true);
+        accountRepository.save(account);
     }
 }

--- a/src/main/java/science/icebreaker/config/SecurityConfig.java
+++ b/src/main/java/science/icebreaker/config/SecurityConfig.java
@@ -112,7 +112,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .dataSource(this.dataSource)
                 .usersByUsernameQuery(
                     "select email as username, password, true "
-                    + "from account where lower(email) = lower(?)"
+                    + "from account where lower(email) = lower(?) "
+                    + "and is_enabled=true"
                 )
                 .authoritiesByUsernameQuery(
                     "select email as username, role as authority "

--- a/src/test/java/science/icebreaker/account/ServicesTest.java
+++ b/src/test/java/science/icebreaker/account/ServicesTest.java
@@ -97,6 +97,7 @@ public class ServicesTest {
     @Order(2)
     public void login_correctData_success() {
         Account account = RegistrationRequestMock.createRegistrationRequest().getAccount();
+        accountService.enableAccount(account.getEmail());
         jwtToken = accountService.login(account);
         assertThat(jwtToken).isNotBlank();
     }

--- a/src/test/java/science/icebreaker/device_availability/DeviceAvailabilityServiceTest.java
+++ b/src/test/java/science/icebreaker/device_availability/DeviceAvailabilityServiceTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
-import science.icebreaker.account.Account;
+import science.icebreaker.account.*;
 import science.icebreaker.exception.AccountCreationException;
 import science.icebreaker.account.AccountProfile;
 import science.icebreaker.account.AccountRepository;
@@ -40,6 +40,7 @@ public class DeviceAvailabilityServiceTest {
     private WikiPageRepository wikiPageRepository;
     private AccountService accountService;
     private AccountRepository accountRepository;
+    private AccountConfirmationRepository accountConfirmationRepository;
     private Account account;
 
     @MockBean
@@ -49,17 +50,21 @@ public class DeviceAvailabilityServiceTest {
     public DeviceAvailabilityServiceTest(DeviceAvailabilityService deviceAvailabilityService,
             DeviceAvailabilityController deviceAvailabilityController,
             AccountService accountService, DeviceAvailabilityRepository deviceAvailabilityRepository,
-            WikiPageRepository wikiPageRepository, AccountRepository accountRepository) {
+            WikiPageRepository wikiPageRepository, AccountRepository accountRepository,
+            AccountConfirmationRepository accountConfirmationRepository) {
         this.deviceAvailabilityService = deviceAvailabilityService;
         this.deviceAvailabilityRepository = deviceAvailabilityRepository;
         this.deviceAvailabilityController = deviceAvailabilityController;
         this.wikiPageRepository = wikiPageRepository;
         this.accountService = accountService;
         this.accountRepository = accountRepository;
+        this.accountConfirmationRepository = accountConfirmationRepository;
     }
 
     @BeforeAll
     public void setupUser() throws AccountCreationException {
+        this.accountConfirmationRepository.deleteAll();
+        this.accountRepository.deleteAll();
         doNothing().when(mailService).sendMail(anyString(), anyString(), anyString());
 
         RegistrationRequest accountInfo = RegistrationRequestMock.createRegistrationRequest(); 


### PR DESCRIPTION
Fixes #42 

-  The logic of creation of an account shouldn't produce inconsistent data due to a non operational mail server. resending tokens should take care of that.

-  Adjusted the login functionality to check if a user is disabled.

I highly recommend that we totally decouple the account_confirmation and account table.