### PR TITLE
Edit wiki page

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation "io.springfox:springfox-boot-starter:3.0.0"
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5:2.9.0'
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
     runtimeOnly 'com.h2database:h2'
 

--- a/src/main/java/science/icebreaker/config/WebConfig.java
+++ b/src/main/java/science/icebreaker/config/WebConfig.java
@@ -1,5 +1,7 @@
 package science.icebreaker.config;
 
+import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -46,5 +48,12 @@ public class WebConfig {
                 }
             }
         };
+    }
+
+    @Bean
+    // Prevents lazy loading of entities
+    // in controllers which could potentially leak sensitive data
+    public Hibernate5Module hibernate5Module() {
+        return new Hibernate5Module();
     }
 }

--- a/src/main/java/science/icebreaker/controller/WikiController.java
+++ b/src/main/java/science/icebreaker/controller/WikiController.java
@@ -3,24 +3,31 @@ package science.icebreaker.controller;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import science.icebreaker.dao.entity.Account;
 import science.icebreaker.dao.entity.Media;
 import science.icebreaker.dao.entity.WikiPage;
 import science.icebreaker.dao.repository.WikiPageRepository;
 import science.icebreaker.data.network.Node;
+import science.icebreaker.data.request.EditWikiPageRequest;
 import science.icebreaker.exception.EntryNotFoundException;
 import science.icebreaker.exception.ErrorCodeEnum;
 import science.icebreaker.exception.IllegalRequestParameterException;
 import science.icebreaker.service.MediaService;
 import science.icebreaker.service.NetworkService;
+import science.icebreaker.service.WikiPageService;
 
 import javax.validation.Valid;
+import java.security.Principal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -33,16 +40,18 @@ public class WikiController {
     private final WikiPageRepository wikiPageRepository;
     private final MediaService mediaService;
     private final NetworkService networkService;
-
+    private final WikiPageService wikiPageService;
 
     public WikiController(
             WikiPageRepository wikiPageRepository,
             MediaService mediaService,
-            NetworkService networkService
+            NetworkService networkService,
+            WikiPageService wikiPageService
     ) {
         this.wikiPageRepository = wikiPageRepository;
         this.mediaService = mediaService;
         this.networkService = networkService;
+        this.wikiPageService = wikiPageService;
     }
 
     @PostMapping("/wiki")
@@ -112,7 +121,19 @@ public class WikiController {
                 .withArgs(id);
         }
     }
+
+    @PutMapping("/wiki/{id}")
+    @ApiOperation("Edit wiki page")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "Entry edited"),
+        @ApiResponse(code = 404, message = "Wiki page entry not found")
+    })
+    public void editWikiPage(
+        @PathVariable Integer id,
+        @RequestBody @Valid EditWikiPageRequest editWikiPageRequest,
+        Principal principal
+    ) {
+        Account account = (Account) ((Authentication) principal).getPrincipal();
+        this.wikiPageService.editWikiPage(id, editWikiPageRequest, account);
+    }
 }
-
-
-

--- a/src/main/java/science/icebreaker/dao/entity/WikiPage.java
+++ b/src/main/java/science/icebreaker/dao/entity/WikiPage.java
@@ -12,6 +12,7 @@ import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -57,6 +58,14 @@ public class WikiPage {
 
     @OneToOne
     private Media media;
+
+    @JoinColumn(name = "last_altered_by")
+    @OneToOne(targetEntity = Account.class, fetch = FetchType.LAZY)
+    private Account lastAlteredBy;
+
+    // If an account is deleted, keep the name of the editor
+    @Column(name = "last_altered_by_name")
+    private String lastAlteredByName;
 
     public WikiPage() {
     }
@@ -141,6 +150,22 @@ public class WikiPage {
 
     public void setMedia(Media media) {
         this.media = media;
+    }
+
+    public Account getLastAlteredBy() {
+        return lastAlteredBy;
+    }
+
+    public void setLastAlteredBy(Account lastAlteredBy) {
+        this.lastAlteredBy = lastAlteredBy;
+    }
+
+    public String getLastAlteredByName() {
+        return lastAlteredByName;
+    }
+
+    public void setLastAlteredByName(String lastAlteredByName) {
+        this.lastAlteredByName = lastAlteredByName;
     }
 
     @Override

--- a/src/main/java/science/icebreaker/data/request/EditWikiPageRequest.java
+++ b/src/main/java/science/icebreaker/data/request/EditWikiPageRequest.java
@@ -1,0 +1,46 @@
+package science.icebreaker.data.request;
+
+import javax.validation.constraints.NotNull;
+
+public class EditWikiPageRequest {
+
+    @NotNull
+    private String title;
+
+    @NotNull
+    private String description;
+
+    @NotNull
+    private String references;
+
+
+    public EditWikiPageRequest() { }
+    public EditWikiPageRequest(
+        String title,
+        String description,
+        String references
+    ) {
+        this.title = title;
+        this.description = description;
+        this.references = references;
+    }
+    public String getTitle() {
+        return title;
+    }
+    public void setTitle(String title) {
+        this.title = title;
+    }
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    public String getReferences() {
+        return references;
+    }
+    public void setReferences(String references) {
+        this.references = references;
+    }
+
+}

--- a/src/main/java/science/icebreaker/service/WikiPageService.java
+++ b/src/main/java/science/icebreaker/service/WikiPageService.java
@@ -1,0 +1,51 @@
+package science.icebreaker.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import science.icebreaker.dao.entity.Account;
+import science.icebreaker.dao.entity.AccountProfile;
+import science.icebreaker.dao.entity.WikiPage;
+import science.icebreaker.dao.repository.WikiPageRepository;
+import science.icebreaker.data.request.EditWikiPageRequest;
+import science.icebreaker.exception.EntryNotFoundException;
+
+@Service
+public class WikiPageService {
+
+    private WikiPageRepository wikiPageRepository;
+    private AccountService accountService;
+
+    public WikiPageService(
+        WikiPageRepository wikiPageRepository,
+        AccountService accountService
+    ) {
+        this.wikiPageRepository = wikiPageRepository;
+        this.accountService = accountService;
+    }
+
+    /**
+     * Edits the wiki page
+     * @param wikiPageId The id of the wiki page to edit
+     * @param editWikiPageRequest The data to edit the wiki page with
+     * @param editor The user who edits the wiki page
+     * @throws EntryNotFoundException no wiki page exists with the given id
+     */
+    @Transactional
+    public void editWikiPage(
+        Integer wikiPageId,
+        EditWikiPageRequest editWikiPageRequest,
+        Account editor
+    ) {
+        WikiPage wikiPage = this.wikiPageRepository.findById(wikiPageId).orElseThrow(EntryNotFoundException::new);
+
+        AccountProfile editorProfile = accountService.getAccountProfile(editor.getId());
+        wikiPage.setLastAlteredByName(editorProfile.getFullName());
+        wikiPage.setLastAlteredBy(editor);
+
+        wikiPage.setTitle(editWikiPageRequest.getTitle());
+        wikiPage.setDescription(editWikiPageRequest.getDescription());
+        wikiPage.setReferences(editWikiPageRequest.getReferences());
+        wikiPageRepository.save(wikiPage);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,6 +10,7 @@ spring.jpa.generate-ddl=false
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 spring.jackson.mapper.accept-case-insensitive-enums=true
+spring.jackson.serialization.FAIL_ON_EMPTY_BEANS=false
 icebreaker.development=false
 icebreaker.host=http://localhost:4200
 icebreaker.jwt-secret=secret

--- a/src/main/resources/db/migration/V5__add_wiki_page_edit_info.sql
+++ b/src/main/resources/db/migration/V5__add_wiki_page_edit_info.sql
@@ -1,0 +1,6 @@
+ALTER TABLE wiki_page 
+ADD COLUMN last_altered_by_name TEXT,
+ADD COLUMN last_altered_by INTEGER,
+ADD CONSTRAINT wiki_page_last_altered_by
+   FOREIGN KEY (last_altered_by)
+   REFERENCES account;

--- a/src/test/java/science/icebreaker/wiki/WikiPageServiceTest.java
+++ b/src/test/java/science/icebreaker/wiki/WikiPageServiceTest.java
@@ -1,0 +1,69 @@
+package science.icebreaker.wiki;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import science.icebreaker.dao.entity.Account;
+import science.icebreaker.dao.entity.AccountProfile;
+import science.icebreaker.dao.entity.WikiPage;
+import science.icebreaker.dao.repository.WikiPageRepository;
+import science.icebreaker.data.request.EditWikiPageRequest;
+import science.icebreaker.service.AccountService;
+import science.icebreaker.service.WikiPageService;
+import science.icebreaker.util.TestHelper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@TestInstance(Lifecycle.PER_CLASS)
+@Transactional
+@SuppressWarnings("ConstantConditions")
+public class WikiPageServiceTest {
+    private final WikiPageService wikiPageService;
+    private final WikiPageRepository wikiPageRepository;
+    private final AccountService accountService;
+    private final TestHelper testHelper;
+
+    @Autowired
+    public WikiPageServiceTest(
+        WikiPageService wikiPageService,
+        WikiPageRepository wikiPageRepository,
+        AccountService accountService,
+        TestHelper testHelper
+    ) {
+        this.wikiPageService = wikiPageService;
+        this.wikiPageRepository = wikiPageRepository;
+        this.accountService = accountService;
+        this.testHelper = testHelper;
+    }
+
+    @Test
+    public void saveDeviceAvailability_success() throws Exception {
+        Account account = testHelper.createAccount();
+        WikiPage wikiPage = testHelper.createWikiPage();
+        EditWikiPageRequest request = new EditWikiPageRequest("NEW title", "NEW Description", "NEW References");
+
+        this.wikiPageService.editWikiPage(wikiPage.getId(), request, account);
+
+        Optional<WikiPage> updatedWikiPageOpt = wikiPageRepository.findById(wikiPage.getId());
+        assertThat(updatedWikiPageOpt).isPresent();
+
+        WikiPage updatedWikiPage = updatedWikiPageOpt.get();
+
+        assertThat(updatedWikiPage.getTitle()).isEqualTo(request.getTitle());
+        assertThat(updatedWikiPage.getDescription()).isEqualTo(request.getDescription());
+        assertThat(updatedWikiPage.getReferences()).isEqualTo(request.getReferences());
+
+        assertThat(updatedWikiPage.getLastAlteredBy()).isEqualTo(account);
+
+        AccountProfile profile = this.accountService.getAccountProfile(account.getId());
+        assertThat(updatedWikiPage.getLastAlteredByName()).isEqualTo(profile.getFullName());
+    }
+}


### PR DESCRIPTION
The return data of fetching wiki pages probably need to be adjusted to reflect the required pieces of data. The frontend might need minor adjustments in accordance with this.

For tracking changes, storing the deltas of edits should be a self encapsulated functionality on its own, which makes options 2 and 3 quite similar in terms of complexity. I'd go for option 3 directly later on.

Editing the images should be straight forward to implement, but It requires a lot of time to test correctly.